### PR TITLE
RageQuit contract with test suite

### DIFF
--- a/src/contracts/RageQuit.sol
+++ b/src/contracts/RageQuit.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {IERC20} from '@openzeppelin/contracts/interfaces/IERC20.sol';
+import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
+import {Pausable} from '@openzeppelin/contracts/security/Pausable.sol';
+
+import {FLOOR} from '@floor/tokens/Floor.sol';
+
+
+/**
+ * Allows tokens to be deposited into the contract and FLOOR to be burned against it
+ * to redeem a share of the assets within the contract.
+ *
+ * For example, if you deposit $400 worth of tokens, this will be mapped to a TVL value
+ * that may be around $700. The user will then receive a value the equivalent of this
+ * TVL value.
+ *
+ * Each funding token that is offered in the contract must maintain the same value when
+ * multipled by the amount. For example, if 100eth of xPUNK token is added, then the same
+ * 100eth value of WETH must be added, and the same is true of all subsequent tokens.
+ */
+contract RageQuit is Ownable, Pausable {
+
+    /// Emitted when funds are added to the contract
+    event FundsAdded(address token, uint amount);
+
+    /// Emitted when someone ragequits
+    event Paperboy(address paperboy, uint ngmi);
+
+    /// FLOOR token to be accepted to be burnt
+    FLOOR public floor;
+
+    /// Store an iterable list of token addresses that are distributed when
+    /// someone ragequits.
+    address[] internal _tokens;
+
+    /// Maps the value of a token to ETH value
+    mapping (address => uint) public tokenValue;
+
+    /**
+     * Defines our FLOOR token that will be burnt for rage quitting.
+     *
+     * @param _floor The FLOOR token address that will be burnt
+     */
+    constructor (address _floor) {
+        floor = FLOOR(_floor);
+    }
+
+    /**
+     * Adds tokens to our contract and sets the value. The value of the funding token
+     * will be used in the calculation of the FLOOR <-> funding token conversion, so it
+     * is important that all token values are taken from the same block for provable
+     * faireness.
+     *
+     * @dev Value should be set in terms of ETH for a single token. If just the token
+     * value wants to be updated without funding additional tokens, then a zero `amount`
+     * can be passed.
+     *
+     * @param token The token address used for funding
+     * @param amount The amount of token to be transferred into the funding
+     * @param value The ETH value of a single token
+     */
+    function fund(address token, uint amount, uint value) public onlyOwner {
+        // Transfer the approved token into this contract
+        if (amount != 0) {
+            IERC20(token).transferFrom(msg.sender, address(this), amount);
+        }
+
+        // Assign our token value in ETH terms
+        tokenValue[token] = value;
+
+        // Check if the token needs adding to our tokens array
+        bool found;
+        for (uint i; i < _tokens.length;) {
+            if (_tokens[i] == token) {
+                found = true;
+                break;
+            }
+            unchecked { ++i; }
+        }
+
+        if (!found) {
+            _tokens.push(token);
+        }
+
+        // Confirm that funds have been added via event
+        emit FundsAdded(token, amount);
+    }
+
+    /**
+     * Allows the TVL FLOOR value to be updated.
+     *
+     * @dev This should be set in ETH terms.
+     *
+     * @param _floorValue ETH value of a single FLOOR token
+     */
+    function setFloorValue(uint _floorValue) public onlyOwner {
+        tokenValue[address(floor)] = _floorValue;
+    }
+
+    /**
+     * Burns FLOOR tokens from the user in exchange for receipt of funding tokens to the
+     * same value.
+     *
+     * @param amount The amount of FLOOR tokens to transfer from the message sender
+     */
+    function ragequit(uint amount) public whenNotPaused {
+        // Ensure that an amount is passed
+        require(amount != 0, 'No tokens burnt');
+
+        // Burn the floor from the caller
+        floor.burnFrom(msg.sender, amount);
+
+        // Iterate over all funding tokens and distribue a share of them to the caller
+        uint tokenCount = _tokens.length;
+        for (uint i; i < tokenCount;) {
+            IERC20(_tokens[i]).transfer(
+                msg.sender,
+                ((tokenValue[address(floor)] * amount)/ tokenValue[_tokens[i]]) / tokenCount
+            );
+
+            unchecked { ++i; }
+        }
+
+        // Goodbye, old friend.
+        emit Paperboy(msg.sender, amount);
+    }
+
+    /**
+     * Exits all tokens from the contract so that we can either refill, or shutdown the
+     * process.
+     *
+     * @dev This function can only be called when the contract is paused.
+     */
+    function rescue() public onlyOwner whenPaused {
+        // Loop through all funding tokens and extract them to caller
+        uint tokenCount = _tokens.length;
+        for (uint i; i < tokenCount;) {
+            IERC20(_tokens[i]).transfer(msg.sender, IERC20(_tokens[i]).balanceOf(address(this)));
+            unchecked { ++i; }
+        }
+
+        // Remove our tokens array so we can start fresh next time
+        delete _tokens;
+    }
+
+    /**
+     * Allows our contract to be paused or unpaused. When paused this will stop rage quits
+     * from taking place and will allow for the `rescue` function to be called.
+     *
+     * @param _paused If the contract should be paused, or unpaused
+     */
+    function pause(bool _paused) public onlyOwner {
+        if (_paused) {
+            _pause();
+        } else {
+            _unpause();
+        }
+    }
+
+    /**
+     * Returns the array of tokens that are currently funding the contract.
+     *
+     * @return address[] An array of funding token addresses
+     */
+    function tokens() public view returns (address[] memory) {
+        return _tokens;
+    }
+
+}

--- a/test/RageQuit.t.sol
+++ b/test/RageQuit.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {ERC20Mock} from '@openzeppelin/contracts/mocks/ERC20Mock.sol';
+
+import {FLOOR} from '@floor/tokens/Floor.sol';
+import {RageQuit} from '@floor/RageQuit.sol';
+
+import {FloorTest} from './utilities/Environments.sol';
+
+
+contract RageQuitTest is FloorTest {
+
+    /// Set our constant token prices
+    uint constant FLOOR_PRICE = 2400000000000000;
+    uint constant FUND1_PRICE = 68180900000000000000;  // PUNK
+    uint constant FUND2_PRICE = 1000000000000000000;   // WETH
+
+    /// Our funding tokens
+    ERC20Mock fundToken1;
+    ERC20Mock fundToken2;
+
+    /// Our native Floor token
+    FLOOR floor;
+
+    /// Ragequit contract to test against
+    RageQuit rageQuit;
+
+    /// Store our test users
+    address alice;
+    address bob;
+    address carol;
+
+    constructor() {
+        // Create 2 tokens that will fund our {RageQuit} contract
+        fundToken1 = new ERC20Mock();
+        fundToken2 = new ERC20Mock();
+
+        // Deploy our {FLOOR} token contract
+        floor = new FLOOR(address(authorityRegistry));
+
+        // Deploy our {RageQuit} contract, referencing our FLOOR token
+        rageQuit = new RageQuit(address(floor));
+
+        // Set up our test users
+        (alice, bob, carol) = (users[0], users[1], users[2]);
+
+        // Set our default FLOOR token price for tests
+        rageQuit.setFloorValue(FLOOR_PRICE);
+
+        // Deal our ERC20 tokens into our {RageQuit} contract to fund it
+        deal(address(fundToken1), address(this), 100 ether);
+        deal(address(fundToken2), address(this), 100_000 ether);
+
+        // Approve our tokens to be used by the {RageQuit} contract
+        fundToken1.approve(address(rageQuit), 100 ether);
+        fundToken2.approve(address(rageQuit), 100_000 ether);
+
+        // Distribute some FLOOR tokens to our test users
+        deal(address(floor), alice, 100_000 ether);
+        deal(address(floor), bob, 10_000 ether);
+        deal(address(floor), carol, 1_000 ether);
+
+        // Approve our {RageQuit} contract to use our test user's floor allocations
+        vm.prank(alice);
+        floor.approve(address(rageQuit), 100_000 ether);
+
+        vm.prank(bob);
+        floor.approve(address(rageQuit), 10_000 ether);
+
+        vm.prank(carol);
+        floor.approve(address(rageQuit), 1_000 ether);
+    }
+
+    function test_CanSetFloorValue(uint value) public {
+        // The token will currently be unknown, so will be 0 value
+        assertEq(rageQuit.tokenValue(address(floor)), FLOOR_PRICE);
+
+        // Update our FLOOR token value and confirm that it was updated successfully
+        rageQuit.setFloorValue(value);
+        assertEq(rageQuit.tokenValue(address(floor)), value);
+    }
+
+    function test_CannotSetFloorValueIfNotOwner(uint value) public {
+        vm.expectRevert();
+        vm.prank(alice);
+        rageQuit.setFloorValue(value);
+    }
+
+    function test_CanFund() public {
+        rageQuit.fund(address(fundToken1), 50 ether, 1);
+        rageQuit.fund(address(fundToken2), 50_000 ether, 2);
+
+        assertEq(rageQuit.tokenValue(address(fundToken1)), 1);
+        assertEq(rageQuit.tokenValue(address(fundToken2)), 2);
+
+        assertEq(fundToken1.balanceOf(address(rageQuit)), 50 ether);
+        assertEq(fundToken2.balanceOf(address(rageQuit)), 50_000 ether);
+
+        rageQuit.fund(address(fundToken1), 50 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 50_000 ether, FUND2_PRICE);
+
+        assertEq(rageQuit.tokenValue(address(fundToken1)), FUND1_PRICE);
+        assertEq(rageQuit.tokenValue(address(fundToken2)), FUND2_PRICE);
+
+        assertEq(fundToken1.balanceOf(address(rageQuit)), 100 ether);
+        assertEq(fundToken2.balanceOf(address(rageQuit)), 100_000 ether);
+    }
+
+    function test_CanRageQuit() public {
+        rageQuit.fund(address(fundToken1), 100 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 100_000 ether, FUND2_PRICE);
+
+        assertEq(floor.balanceOf(alice), 100_000 ether);
+        assertEq(fundToken1.balanceOf(alice), 0);
+        assertEq(fundToken2.balanceOf(alice), 0);
+
+        vm.prank(alice);
+        rageQuit.ragequit(10_000 ether);
+
+        assertEq(floor.balanceOf(alice), 90_000 ether);
+        assertEq(fundToken1.balanceOf(alice), 176002370165251558);   // 0.1760 PUNK
+        assertEq(fundToken2.balanceOf(alice), 12000000000000000000); // 12.000 WETH
+
+        vm.prank(alice);
+        rageQuit.ragequit(20_000 ether);
+
+        assertEq(floor.balanceOf(alice), 70_000 ether);
+        assertEq(fundToken1.balanceOf(alice), 528007110495754675);   // 0.5280 PUNK
+        assertEq(fundToken2.balanceOf(alice), 36000000000000000000); // 36.000 WETH
+    }
+
+    function test_CannotRageQuitZeroTokens() public {
+        vm.expectRevert();
+        vm.prank(alice);
+        rageQuit.ragequit(0);
+    }
+
+    function test_CannotRageQuitWithInsufficientFloorTokens(uint amount) public {
+        vm.assume(amount > 1_000 ether);
+
+        rageQuit.fund(address(fundToken1), 50 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 50_000 ether, FUND2_PRICE);
+
+        vm.expectRevert();
+        vm.prank(carol);
+        rageQuit.ragequit(amount);
+    }
+
+    function test_CannotRageQuitAboveFundHoldings() public {
+        rageQuit.fund(address(fundToken1), 50 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 1 ether, FUND2_PRICE);
+
+        vm.expectRevert();
+        vm.prank(alice);
+        rageQuit.ragequit(1_000 ether);
+
+        rageQuit.pause(true);
+        rageQuit.rescue();
+        rageQuit.pause(false);
+
+        rageQuit.fund(address(fundToken1), 0 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 50_000 ether, FUND2_PRICE);
+
+        vm.expectRevert();
+        vm.prank(alice);
+        rageQuit.ragequit(1_000 ether);
+    }
+
+    function test_CanPauseRageQuitLogic() public {
+        rageQuit.fund(address(fundToken1), 50 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 50_000 ether, FUND2_PRICE);
+
+        rageQuit.pause(true);
+
+        vm.expectRevert();
+        vm.prank(alice);
+        rageQuit.ragequit(1_000 ether);
+    }
+
+    function test_CanRescue() public {
+        rageQuit.fund(address(fundToken1), 50 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 50_000 ether, FUND2_PRICE);
+
+        rageQuit.pause(true);
+
+        rageQuit.rescue();
+
+        address[] memory tokens = rageQuit.tokens();
+        assertEq(tokens.length, 0);
+    }
+
+    function test_CannotRescueWhenNotPaused() public {
+        rageQuit.fund(address(fundToken1), 50 ether, FUND1_PRICE);
+        rageQuit.fund(address(fundToken2), 50_000 ether, FUND2_PRICE);
+
+        vm.expectRevert();
+        rageQuit.rescue();
+    }
+
+}


### PR DESCRIPTION
This adds a rage quit contract that allows for funding tokens to be added. These will then be distributed to users based on the equivalent TVL value burnt from FLOOR.

The formula to determine the amount of funding tokens received is calculated as:
```
( ( FLOOR_PRICE * AMOUNT_BURNT ) / FUND_TOKEN_PRICE ) / NUMBER_OF_FUND_TOKENS
```

An example of this formula in action can be found here:
https://docs.google.com/spreadsheets/d/13GFNKp0wHdCXAyiHiofNu5TgYJYqMIEoSG4JGuhy9Ik/edit?usp=sharing