### PR TITLE
[16] Allow specific GemSwap contract to be assigned

### DIFF
--- a/src/contracts/sweepers/Gem.sol
+++ b/src/contracts/sweepers/Gem.sol
@@ -23,6 +23,9 @@ contract GemSweeper is ISweeper, Ownable {
         override
         returns (string memory)
     {
+        // Confirm that a GemSwap contract has been set
+        require(gemSwap != address(0), 'No GemSwap contract set');
+
         // Sweeps from GemSwap
         (bool success,) = payable(gemSwap).call{value: msg.value}(data);
         require(success, 'Unable to sweep');


### PR DESCRIPTION
This removes the GemSwap contract address being passed in the request which could be exploited if it went to a non-owner sweep / holder sweep