### PR TITLE
Remove setCurrentEpoch from codebase

### DIFF
--- a/src/contracts/EpochManager.sol
+++ b/src/contracts/EpochManager.sol
@@ -40,16 +40,6 @@ contract EpochManager is IEpochManager, Ownable {
     address[] public epochEndTriggers;
 
     /**
-     * Allows a new epoch to be set. This should, in theory, only be set to one
-     * above the existing `currentEpoch`.
-     *
-     * @param _currentEpoch The new epoch to set
-     */
-    function setCurrentEpoch(uint _currentEpoch) external onlyOwner {
-        currentEpoch = _currentEpoch;
-    }
-
-    /**
      * Will return if the current epoch is a collection addition vote.
      *
      * @return bool If the current epoch is a collection addition

--- a/src/interfaces/EpochManager.sol
+++ b/src/interfaces/EpochManager.sol
@@ -26,14 +26,6 @@ interface IEpochManager {
     function collectionEpochs(uint _epoch) external view returns (uint);
 
     /**
-     * Allows a new epoch to be set. This should, in theory, only be set to one
-     * above the existing `currentEpoch`.
-     *
-     * @param _currentEpoch The new epoch to set
-     */
-    function setCurrentEpoch(uint _currentEpoch) external;
-
-    /**
      * Will return if the current epoch is a collection addition vote.
      *
      * @return If the current epoch is a collection addition

--- a/test/EpochManager.t.sol
+++ b/test/EpochManager.t.sol
@@ -128,21 +128,6 @@ contract EpochManagerTest is FloorTest {
         treasury.approveSweeper(manualSweeper, true);
     }
 
-    function test_CanSetCurrentEpoch(uint epoch) external {
-        // Confirm we have a default epoch of zero
-        assertEq(epochManager.currentEpoch(), 0);
-
-        // Set our epoch and confirm that it has changed correctly
-        epochManager.setCurrentEpoch(epoch);
-        assertEq(epochManager.currentEpoch(), epoch);
-    }
-
-    function test_CannotSetCurrentEpochWithoutPermission() external {
-        vm.expectRevert('Ownable: caller is not the owner');
-        vm.prank(alice);
-        epochManager.setCurrentEpoch(3);
-    }
-
     function test_CanSetContracts() external {
         epochManager.setContracts(
             address(2), // newCollectionWars

--- a/test/staking/VeFloorStaking.t.sol
+++ b/test/staking/VeFloorStaking.t.sol
@@ -70,7 +70,7 @@ contract VeFloorStakingTest is FloorTest {
     function test_ShouldIncreaseUnlockTimeForDeposit() external {
         veFloor.deposit(100 ether, 3);
 
-        epochManager.setCurrentEpoch(2);
+        setCurrentEpoch(address(epochManager), 2);
 
         (uint160 epochStart, uint8 epochCount, uint88 amount) = veFloor.depositors(address(this));
         assertEq(epochStart, 0);
@@ -95,7 +95,7 @@ contract VeFloorStakingTest is FloorTest {
 
         // Deposit for 8 epochs
         veFloor.deposit(100 ether, 2);
-        epochManager.setCurrentEpoch(2);
+        setCurrentEpoch(address(epochManager), 2);
 
         veFloor.earlyWithdrawTo(address(this), 0 ether, 100 ether);
 
@@ -130,7 +130,7 @@ contract VeFloorStakingTest is FloorTest {
     }
 
     function test_ShouldReturnZeroBeforeDepositMade() external {
-        epochManager.setCurrentEpoch(1);
+        setCurrentEpoch(address(epochManager), 1);
 
         veFloor.deposit(1 ether, MAX_EPOCH_INDEX);
 
@@ -140,7 +140,7 @@ contract VeFloorStakingTest is FloorTest {
     function test_ShouldWithdrawUsersDeposit() external {
         veFloor.deposit(100 ether, 1);
 
-        epochManager.setCurrentEpoch(4);
+        setCurrentEpoch(address(epochManager), 4);
 
         uint balanceaddr = floor.balanceOf(address(this));
 
@@ -157,7 +157,7 @@ contract VeFloorStakingTest is FloorTest {
     function test_ShouldWithdrawUsersDepositAndSentTokensToOtherAddress() external {
         veFloor.deposit(100 ether, 1);
 
-        epochManager.setCurrentEpoch(4);
+        setCurrentEpoch(address(epochManager), 4);
 
         uint balanceaddr = floor.balanceOf(address(this));
         uint balanceAddr1 = floor.balanceOf(alice);
@@ -207,7 +207,7 @@ contract VeFloorStakingTest is FloorTest {
 
     function test_EarlyWithdrawToShouldNotWorkAfterUnlockTime() external {
         veFloor.deposit(1 ether, 3);
-        epochManager.setCurrentEpoch(26);
+        setCurrentEpoch(address(epochManager), 26);
 
         vm.expectRevert(VeFloorStaking.StakeUnlocked.selector);
         veFloor.earlyWithdrawTo(address(this), 1, 1);
@@ -250,7 +250,7 @@ contract VeFloorStakingTest is FloorTest {
         veFloor.deposit(1 ether, MAX_EPOCH_INDEX);
 
         // Move our epoch forward to 20 weeks
-        epochManager.setCurrentEpoch(20);
+        setCurrentEpoch(address(epochManager), 20);
 
         // Set Alice to receive fees
         veFloor.setFeeReceiver(alice);
@@ -275,22 +275,22 @@ contract VeFloorStakingTest is FloorTest {
 
         (uint rest2YearsLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
-        epochManager.setCurrentEpoch(2);
+        setCurrentEpoch(address(epochManager), 2);
         (uint rest1HalfYearsLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
-        epochManager.setCurrentEpoch(4);
+        setCurrentEpoch(address(epochManager), 4);
         (uint rest1YearsLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
-        epochManager.setCurrentEpoch(8);
+        setCurrentEpoch(address(epochManager), 8);
         (uint restHalfYearsLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
-        epochManager.setCurrentEpoch(12);
+        setCurrentEpoch(address(epochManager), 12);
         (uint restMonthLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
-        epochManager.setCurrentEpoch(20);
+        setCurrentEpoch(address(epochManager), 20);
         (uint restWeekLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
-        epochManager.setCurrentEpoch(22);
+        setCurrentEpoch(address(epochManager), 22);
         (uint restDayLoss,,) = veFloor.earlyWithdrawLoss(address(this));
 
         assertGt(rest2YearsLoss, rest1HalfYearsLoss);
@@ -306,7 +306,7 @@ contract VeFloorStakingTest is FloorTest {
         veFloor.deposit(1 ether, MAX_EPOCH_INDEX);
 
         // Shift our epoch to 12 weeks
-        epochManager.setCurrentEpoch(12);
+        setCurrentEpoch(address(epochManager), 12);
 
         // Set Alice to receive fees
         veFloor.setFeeReceiver(alice);
@@ -329,37 +329,37 @@ contract VeFloorStakingTest is FloorTest {
     function test_CanDetermineEarlyWithdrawLoss() external {
         veFloor.deposit(100 ether, MAX_EPOCH_INDEX);
 
-        epochManager.setCurrentEpoch(0);
+        setCurrentEpoch(address(epochManager), 0);
         (uint loss, uint ret, bool canWithdraw) = veFloor.earlyWithdrawLoss(address(this));
         assertEq(loss, 100 ether);
         assertEq(ret, 0 ether);
         assertEq(canWithdraw, true);
 
-        epochManager.setCurrentEpoch(2);
+        setCurrentEpoch(address(epochManager), 2);
         (loss, ret, canWithdraw) = veFloor.earlyWithdrawLoss(address(this));
         assertEq(loss, 91666666666666666667);
         assertEq(ret, 8333333333333333333);
         assertEq(canWithdraw, true);
 
-        epochManager.setCurrentEpoch(4);
+        setCurrentEpoch(address(epochManager), 4);
         (loss, ret, canWithdraw) = veFloor.earlyWithdrawLoss(address(this));
         assertEq(loss, 83333333333333333334);
         assertEq(ret, 16666666666666666666);
         assertEq(canWithdraw, true);
 
-        epochManager.setCurrentEpoch(8);
+        setCurrentEpoch(address(epochManager), 8);
         (loss, ret, canWithdraw) = veFloor.earlyWithdrawLoss(address(this));
         assertEq(loss, 66666666666666666667);
         assertEq(ret, 33333333333333333333);
         assertEq(canWithdraw, true);
 
-        epochManager.setCurrentEpoch(12);
+        setCurrentEpoch(address(epochManager), 12);
         (loss, ret, canWithdraw) = veFloor.earlyWithdrawLoss(address(this));
         assertEq(loss, 50 ether);
         assertEq(ret, 50 ether);
         assertEq(canWithdraw, true);
 
-        epochManager.setCurrentEpoch(24);
+        setCurrentEpoch(address(epochManager), 24);
         (loss, ret, canWithdraw) = veFloor.earlyWithdrawLoss(address(this));
         assertEq(loss, 0 ether);
         assertEq(ret, 100 ether);
@@ -369,7 +369,7 @@ contract VeFloorStakingTest is FloorTest {
     // Example 1 : Lock for 12 epochs, call refresh with 0 epochs passed. Should not change.
     function test_CanRefreshLock_1(uint160 _startEpoch) external {
         // Set our current epoch to our test value
-        epochManager.setCurrentEpoch(_startEpoch);
+        setCurrentEpoch(address(epochManager), _startEpoch);
 
         // Set our voting contracts. The actual address does not matter, as we only need to
         // use it to prank the caller.
@@ -398,7 +398,7 @@ contract VeFloorStakingTest is FloorTest {
         vm.assume(_startEpoch < type(uint160).max - 10);
 
         // Set our current epoch to our test value
-        epochManager.setCurrentEpoch(_startEpoch);
+        setCurrentEpoch(address(epochManager), _startEpoch);
 
         // Set our voting contracts. The actual address does not matter, as we only need to
         // use it to prank the caller.
@@ -412,7 +412,7 @@ contract VeFloorStakingTest is FloorTest {
         assertEq(veFloor.votingPowerOf(address(this)), 0.5 ether);
 
         // Move our epoch forward after the deposit
-        epochManager.setCurrentEpoch(_startEpoch + 10);
+        setCurrentEpoch(address(epochManager), _startEpoch + 10);
 
         vm.prank(address(1));
         veFloor.refreshLock(address(this));
@@ -430,7 +430,7 @@ contract VeFloorStakingTest is FloorTest {
         vm.assume(_startEpoch < type(uint160).max - 11);
 
         // Set our current epoch to our test value
-        epochManager.setCurrentEpoch(_startEpoch);
+        setCurrentEpoch(address(epochManager), _startEpoch);
 
         // Set our voting contracts. The actual address does not matter, as we only need to
         // use it to prank the caller.
@@ -444,7 +444,7 @@ contract VeFloorStakingTest is FloorTest {
         assertEq(veFloor.votingPowerOf(address(this)), 0.5 ether);
 
         // Move our epoch forward after the deposit
-        epochManager.setCurrentEpoch(_startEpoch + 11);
+        setCurrentEpoch(address(epochManager), _startEpoch + 11);
 
         vm.prank(address(1));
         veFloor.refreshLock(address(this));
@@ -462,7 +462,7 @@ contract VeFloorStakingTest is FloorTest {
         vm.assume(_startEpoch < type(uint160).max - 12);
 
         // Set our current epoch to our test value
-        epochManager.setCurrentEpoch(_startEpoch);
+        setCurrentEpoch(address(epochManager), _startEpoch);
 
         // Set our voting contracts. The actual address does not matter, as we only need to
         // use it to prank the caller.
@@ -476,7 +476,7 @@ contract VeFloorStakingTest is FloorTest {
         assertEq(veFloor.votingPowerOf(address(this)), 0.5 ether);
 
         // Move our epoch forward after the deposit
-        epochManager.setCurrentEpoch(_startEpoch + 10);
+        setCurrentEpoch(address(epochManager), _startEpoch + 10);
 
         vm.prank(address(1));
         veFloor.refreshLock(address(this));
@@ -494,7 +494,7 @@ contract VeFloorStakingTest is FloorTest {
         vm.assume(_startEpoch < type(uint160).max - 24);
 
         // Set our current epoch to our test value
-        epochManager.setCurrentEpoch(_startEpoch);
+        setCurrentEpoch(address(epochManager), _startEpoch);
 
         // Set our voting contracts. The actual address does not matter, as we only need to
         // use it to prank the caller.
@@ -508,7 +508,7 @@ contract VeFloorStakingTest is FloorTest {
         assertEq(veFloor.votingPowerOf(address(this)), 0.5 ether);
 
         // Move our epoch forward after the deposit
-        epochManager.setCurrentEpoch(_startEpoch + 24);
+        setCurrentEpoch(address(epochManager), _startEpoch + 24);
 
         vm.prank(address(1));
         veFloor.refreshLock(address(this));

--- a/test/strategies/DistributedRevenueStakingStrategy.t.sol
+++ b/test/strategies/DistributedRevenueStakingStrategy.t.sol
@@ -130,7 +130,7 @@ contract DistributedRevenueStakingStrategyTest is FloorTest {
 
         // If we shift our epoch forwards we should see that we now have 20 ether
         // allocation of our rewards.
-        epochManager.setCurrentEpoch(1);
+        setCurrentEpoch(address(epochManager), 1);
 
         (snapshotTokens, snapshotAmounts) = strategyFactory.snapshot(strategyId, epochManager.currentEpoch());
         assertEq(snapshotTokens[0], WETH);
@@ -147,7 +147,7 @@ contract DistributedRevenueStakingStrategyTest is FloorTest {
         assertEq(totalRewardAmounts[0], 40 ether);
 
         // Our last snapshot call should only hold the remaining 20 + 10 ETH
-        epochManager.setCurrentEpoch(2);
+        setCurrentEpoch(address(epochManager), 2);
         (snapshotTokens, snapshotAmounts) = strategyFactory.snapshot(strategyId, epochManager.currentEpoch());
         assertEq(snapshotTokens[0], WETH);
         assertEq(snapshotAmounts[0], 10 ether);
@@ -163,7 +163,7 @@ contract DistributedRevenueStakingStrategyTest is FloorTest {
         assertEq(totalRewardAmounts[0], 50 ether);
 
         // Shifting to after our epoch deposits, we should no longer have rewards
-        epochManager.setCurrentEpoch(3);
+        setCurrentEpoch(address(epochManager), 3);
         (snapshotTokens, snapshotAmounts) = strategyFactory.snapshot(strategyId, epochManager.currentEpoch());
         assertEq(snapshotTokens[0], WETH);
         assertEq(snapshotAmounts[0], 0 ether);
@@ -206,7 +206,7 @@ contract DistributedRevenueStakingStrategyTest is FloorTest {
 
         // Wait until the third epoch and then deposit an additional ether to show that
         // it is distributed from the current epoch onwards.
-        epochManager.setCurrentEpoch(3);
+        setCurrentEpoch(address(epochManager), 3);
 
         // Deposit another 5 ether
         vm.prank(testUser);
@@ -237,7 +237,7 @@ contract DistributedRevenueStakingStrategyTest is FloorTest {
         assertEq(IERC20(WETH).balanceOf(address(this)), 0);
 
         // Move our epoch forwards
-        epochManager.setCurrentEpoch(1);
+        setCurrentEpoch(address(epochManager), 1);
 
         // Confirm we can withdraw from past epoch
         strategyFactory.withdraw(strategyId, abi.encodeWithSelector(strategy.withdrawErc20.selector));
@@ -249,7 +249,7 @@ contract DistributedRevenueStakingStrategyTest is FloorTest {
         assertEq(IERC20(WETH).balanceOf(address(this)), 20 ether);
 
         // Move our epoch forward to last one
-        epochManager.setCurrentEpoch(3);
+        setCurrentEpoch(address(epochManager), 3);
 
         // Confirm we can withdraw from past epochs, but trying to withdraw from
         // current epoch will revert.

--- a/test/utilities/Environments.sol
+++ b/test/utilities/Environments.sol
@@ -2,14 +2,18 @@
 
 pragma solidity ^0.8.0;
 
-import {Test} from 'forge-std/Test.sol';
+import {stdStorage, StdStorage, Test} from 'forge-std/Test.sol';
 
 import {AuthorityControl} from '@floor/authorities/AuthorityControl.sol';
 import {AuthorityRegistry} from '@floor/authorities/AuthorityRegistry.sol';
 
+import {IEpochManager} from '@floor-interfaces/EpochManager.sol';
+
 import {Utilities} from '../utilities/Utilities.sol';
 
 contract FloorTest is Test {
+    using stdStorage for StdStorage;
+
     uint mainnetFork;
 
     AuthorityControl authorityControl;
@@ -95,5 +99,16 @@ contract FloorTest is Test {
             0xdC774D5260ec66e5DD4627E1DD800Eff3911345C, // _stakingZap
             0x2374a32ab7b4f7BE058A69EA99cb214BFF4868d3 // _unstakingZap
         );
+    }
+
+    /**
+     * Allows the current epoch to be manipulated
+     */
+    function setCurrentEpoch(address epochManager, uint epoch) internal {
+        // Manually target and store a new epoch
+        stdstore.target(epochManager).sig('currentEpoch()').checked_write(epoch);
+
+        // Confirm that the current epoch has been correctly updated
+        assertEq(IEpochManager(epochManager).currentEpoch(), epoch);
     }
 }

--- a/test/voting/NewCollectionWars.t.sol
+++ b/test/voting/NewCollectionWars.t.sol
@@ -268,7 +268,7 @@ contract NewCollectionWarsTest is FloorTest {
         vm.assume(currentEpoch > 0);
         vm.assume(currentEpoch <= 10);
 
-        epochManager.setCurrentEpoch(currentEpoch);
+        setCurrentEpoch(address(epochManager), currentEpoch);
 
         vm.prank(address(epochManager));
         newCollectionWars.endFloorWar();


### PR DESCRIPTION
Removes the `setCurrentEpoch` function from the `{EpochManager}` and replaces it with the ability to `store` an epoch value directly against the `{EpochManager}` in the required test suites.